### PR TITLE
 Added support for explicit pools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,18 +4,17 @@
 
     <groupId>com.hystrix</groupId>
     <artifactId>hystrix-configurator</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7-R-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>hystrix-configurator</name>
     <url>http://maven.apache.org</url>
 
     <distributionManagement>
-        <repository>
-            <id>clojars</id>
-            <name>Clojars repository</name>
-            <url>https://clojars.org/repo</url>
-        </repository>
+        <snapshotRepository>
+            <id>phonepe-snapshots</id>
+            <url>http://artifactory.phonepe.com/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hystrix.version>1.5.3</hystrix.version>
+        <hystrix.version>1.5.18</hystrix.version>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
         <junit.version>4.12</junit.version>
         <lombok.version>1.16.6</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,18 @@
 
     <groupId>com.hystrix</groupId>
     <artifactId>hystrix-configurator</artifactId>
-    <version>0.0.7-R-SNAPSHOT</version>
+    <version>0.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>hystrix-configurator</name>
     <url>http://maven.apache.org</url>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>phonepe-snapshots</id>
-            <url>http://artifactory.phonepe.com/content/repositories/snapshots</url>
-        </snapshotRepository>
+        <repository>
+            <id>clojars</id>
+            <name>Clojars repository</name>
+            <url>https://clojars.org/repo</url>
+        </repository>
     </distributionManagement>
 
     <scm>

--- a/src/main/java/com/hystrix/configurator/config/CommandThreadPoolConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/CommandThreadPoolConfig.java
@@ -1,0 +1,52 @@
+package com.hystrix.configurator.config;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CommandThreadPoolConfig {
+
+    private boolean semaphoreIsolation = false;
+
+    private String pool;
+
+    private int concurrency = 8;
+
+    private int maxRequestQueueSize = 128;
+
+    private int dynamicRequestQueueSize = 16;
+
+    private int timeout = 1000;
+
+    @Builder
+    public CommandThreadPoolConfig(boolean semaphoreIsolation,
+                                   String pool,
+                                   int concurrency,
+                                   int maxRequestQueueSize,
+                                   int dynamicRequestQueueSize,
+                                   int timeout) {
+        this.semaphoreIsolation = semaphoreIsolation;
+        this.pool = pool;
+        this.concurrency = concurrency;
+        this.maxRequestQueueSize = maxRequestQueueSize;
+        this.dynamicRequestQueueSize = dynamicRequestQueueSize;
+        this.timeout = timeout;
+    }
+
+    //Default values
+    public static class CommandThreadPoolConfigBuilder {
+
+        private boolean semaphoreIsolation = false;
+
+        private int concurrency = Runtime.getRuntime().availableProcessors();
+
+        private int maxRequestQueueSize = Runtime.getRuntime().availableProcessors() * 4;
+
+        private int dynamicRequestQueueSize = Runtime.getRuntime().availableProcessors() * 2;
+
+        private int timeout = 1000;
+
+    }
+}

--- a/src/main/java/com/hystrix/configurator/config/CommandThreadPoolConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/CommandThreadPoolConfig.java
@@ -38,6 +38,8 @@ public class CommandThreadPoolConfig {
     //Default values
     public static class CommandThreadPoolConfigBuilder {
 
+        private String pool;
+
         private boolean semaphoreIsolation = false;
 
         private int concurrency = Runtime.getRuntime().availableProcessors();

--- a/src/main/java/com/hystrix/configurator/config/HystrixCommandConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixCommandConfig.java
@@ -34,7 +34,7 @@ public class HystrixCommandConfig {
     private String name;
 
     @Valid
-    private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
+    private CommandThreadPoolConfig threadPool = CommandThreadPoolConfig.builder().build();
 
     private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
 
@@ -44,7 +44,9 @@ public class HystrixCommandConfig {
 
     @Builder
     public HystrixCommandConfig(String name,
-                                ThreadPoolConfig threadPool,
+                                boolean semaphoreIsolation,
+                                int timeout,
+                                CommandThreadPoolConfig threadPool,
                                 CircuitBreakerConfig circuitBreaker,
                                 MetricsConfig metrics,
                                 boolean fallbackEnabled) {
@@ -57,7 +59,8 @@ public class HystrixCommandConfig {
 
     public static class HystrixCommandConfigBuilder {
 
-        private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
+        @Valid
+        private CommandThreadPoolConfig threadPool = CommandThreadPoolConfig.builder().build();
 
         private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
 

--- a/src/main/java/com/hystrix/configurator/config/HystrixCommandConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixCommandConfig.java
@@ -20,6 +20,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 /**
  * @author phaneesh
  */
@@ -27,8 +30,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class HystrixCommandConfig {
 
+    @NotNull
     private String name;
 
+    @Valid
     private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
 
     private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
@@ -38,8 +43,11 @@ public class HystrixCommandConfig {
     private boolean fallbackEnabled = true;
 
     @Builder
-    public HystrixCommandConfig(String name, ThreadPoolConfig threadPool, CircuitBreakerConfig circuitBreaker,
-                                MetricsConfig metrics, boolean fallbackEnabled) {
+    public HystrixCommandConfig(String name,
+                                ThreadPoolConfig threadPool,
+                                CircuitBreakerConfig circuitBreaker,
+                                MetricsConfig metrics,
+                                boolean fallbackEnabled) {
         this.name = name;
         this.threadPool = threadPool;
         this.circuitBreaker = circuitBreaker;

--- a/src/main/java/com/hystrix/configurator/config/HystrixConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixConfig.java
@@ -24,6 +24,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author phaneesh
@@ -36,14 +37,14 @@ public class HystrixConfig {
     private HystrixDefaultConfig defaultConfig = HystrixDefaultConfig.builder().build();
 
     @Valid
-    private List<ThreadPoolConfig> pools = Collections.emptyList();
+    private Map<String, ThreadPoolConfig> pools = Collections.emptyMap();
 
     @Valid
     private List<HystrixCommandConfig> commands = Collections.emptyList();
 
     @Builder
     public HystrixConfig(HystrixDefaultConfig defaultConfig,
-                         List<ThreadPoolConfig> pools,
+                         Map<String, ThreadPoolConfig> pools,
                          List<HystrixCommandConfig> commands) {
         this.defaultConfig = defaultConfig;
         this.pools = pools;
@@ -53,6 +54,8 @@ public class HystrixConfig {
     public static class HystrixConfigBuilder {
 
         private HystrixDefaultConfig defaultConfig = HystrixDefaultConfig.builder().build();
+
+        private Map<String, ThreadPoolConfig> pools = Collections.emptyMap();
 
         private List<HystrixCommandConfig> commands = Collections.emptyList();
 

--- a/src/main/java/com/hystrix/configurator/config/HystrixConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixConfig.java
@@ -49,4 +49,12 @@ public class HystrixConfig {
         this.pools = pools;
         this.commands = commands;
     }
+
+    public static class HystrixConfigBuilder {
+
+        private HystrixDefaultConfig defaultConfig = HystrixDefaultConfig.builder().build();
+
+        private List<HystrixCommandConfig> commands = Collections.emptyList();
+
+    }
 }

--- a/src/main/java/com/hystrix/configurator/config/HystrixConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixConfig.java
@@ -16,8 +16,11 @@
 
 package com.hystrix.configurator.config;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.List;
@@ -32,19 +35,18 @@ public class HystrixConfig {
     @NotNull
     private HystrixDefaultConfig defaultConfig = HystrixDefaultConfig.builder().build();
 
+    @Valid
+    private List<ThreadPoolConfig> pools = Collections.emptyList();
+
+    @Valid
     private List<HystrixCommandConfig> commands = Collections.emptyList();
 
     @Builder
-    public HystrixConfig(HystrixDefaultConfig defaultConfig, List<HystrixCommandConfig> commands) {
+    public HystrixConfig(HystrixDefaultConfig defaultConfig,
+                         List<ThreadPoolConfig> pools,
+                         List<HystrixCommandConfig> commands) {
         this.defaultConfig = defaultConfig;
+        this.pools = pools;
         this.commands = commands;
-    }
-
-    public static class HystrixConfigBuilder {
-
-        private HystrixDefaultConfig defaultConfig = HystrixDefaultConfig.builder().build();
-
-        private List<HystrixCommandConfig> commands = Collections.emptyList();
-
     }
 }

--- a/src/main/java/com/hystrix/configurator/config/HystrixDefaultConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixDefaultConfig.java
@@ -23,14 +23,4 @@ public class HystrixDefaultConfig {
         this.circuitBreaker = circuitBreaker;
         this.metrics = metrics;
     }
-
-    public static class HystrixDefaultConfigBuilder {
-
-        private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
-
-        private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
-
-        private MetricsConfig metrics = MetricsConfig.builder().build();
-
-    }
 }

--- a/src/main/java/com/hystrix/configurator/config/HystrixDefaultConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixDefaultConfig.java
@@ -11,14 +11,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class HystrixDefaultConfig {
 
-    private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
+    private CommandThreadPoolConfig threadPool = CommandThreadPoolConfig.builder().build();
 
     private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
 
     private MetricsConfig metrics = MetricsConfig.builder().build();
 
     @Builder
-    public HystrixDefaultConfig(ThreadPoolConfig threadPool, CircuitBreakerConfig circuitBreaker, MetricsConfig metrics) {
+    public HystrixDefaultConfig(int timeout,
+                                CommandThreadPoolConfig threadPool,
+                                CircuitBreakerConfig circuitBreaker,
+                                MetricsConfig metrics) {
         this.threadPool = threadPool;
         this.circuitBreaker = circuitBreaker;
         this.metrics = metrics;
@@ -26,7 +29,7 @@ public class HystrixDefaultConfig {
 
     public static class HystrixDefaultConfigBuilder {
 
-        private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
+        private CommandThreadPoolConfig threadPool = CommandThreadPoolConfig.builder().build();
 
         private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
 

--- a/src/main/java/com/hystrix/configurator/config/HystrixDefaultConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/HystrixDefaultConfig.java
@@ -23,4 +23,14 @@ public class HystrixDefaultConfig {
         this.circuitBreaker = circuitBreaker;
         this.metrics = metrics;
     }
+
+    public static class HystrixDefaultConfigBuilder {
+
+        private ThreadPoolConfig threadPool = ThreadPoolConfig.builder().build();
+
+        private CircuitBreakerConfig circuitBreaker = CircuitBreakerConfig.builder().build();
+
+        private MetricsConfig metrics = MetricsConfig.builder().build();
+
+    }
 }

--- a/src/main/java/com/hystrix/configurator/config/ThreadPoolConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/ThreadPoolConfig.java
@@ -20,8 +20,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.HashSet;
-import java.util.Set;
+import javax.validation.constraints.NotNull;
 
 /**
  * @author phaneesh
@@ -29,6 +28,9 @@ import java.util.Set;
 @Data
 @NoArgsConstructor
 public class ThreadPoolConfig {
+
+    @NotNull
+    private String pool = "default";
 
     private boolean semaphoreIsolation = false;
 
@@ -41,7 +43,13 @@ public class ThreadPoolConfig {
     private int timeout = 1000;
 
     @Builder
-    public ThreadPoolConfig(boolean semaphoreIsolation, int concurrency, int maxRequestQueueSize, int dynamicRequestQueueSize, int timeout) {
+    public ThreadPoolConfig(String pool,
+                            boolean semaphoreIsolation,
+                            int concurrency,
+                            int maxRequestQueueSize,
+                            int dynamicRequestQueueSize,
+                            int timeout) {
+        this.pool = pool;
         this.semaphoreIsolation = semaphoreIsolation;
         this.concurrency = concurrency;
         this.maxRequestQueueSize = maxRequestQueueSize;
@@ -51,6 +59,8 @@ public class ThreadPoolConfig {
 
     //Default values
     public static class ThreadPoolConfigBuilder {
+
+        private String pool = "default";
 
         private boolean semaphoreIsolation = false;
 

--- a/src/main/java/com/hystrix/configurator/config/ThreadPoolConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/ThreadPoolConfig.java
@@ -30,7 +30,7 @@ import javax.validation.constraints.NotNull;
 public class ThreadPoolConfig {
 
     @NotNull
-    private String pool = "default";
+    private String pool;
 
     private boolean semaphoreIsolation = false;
 
@@ -60,7 +60,7 @@ public class ThreadPoolConfig {
     //Default values
     public static class ThreadPoolConfigBuilder {
 
-        private String pool = "default";
+        private String pool;
 
         private boolean semaphoreIsolation = false;
 

--- a/src/main/java/com/hystrix/configurator/config/ThreadPoolConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/ThreadPoolConfig.java
@@ -20,8 +20,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-
 /**
  * @author phaneesh
  */
@@ -29,40 +27,23 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class ThreadPoolConfig {
 
-    @NotNull
-    private String pool;
-
-    private boolean semaphoreIsolation = false;
-
     private int concurrency = 8;
 
     private int maxRequestQueueSize = 128;
 
     private int dynamicRequestQueueSize = 16;
 
-    private int timeout = 1000;
-
     @Builder
-    public ThreadPoolConfig(String pool,
-                            boolean semaphoreIsolation,
-                            int concurrency,
+    public ThreadPoolConfig(int concurrency,
                             int maxRequestQueueSize,
-                            int dynamicRequestQueueSize,
-                            int timeout) {
-        this.pool = pool;
-        this.semaphoreIsolation = semaphoreIsolation;
+                            int dynamicRequestQueueSize) {
         this.concurrency = concurrency;
         this.maxRequestQueueSize = maxRequestQueueSize;
         this.dynamicRequestQueueSize = dynamicRequestQueueSize;
-        this.timeout = timeout;
     }
 
     //Default values
     public static class ThreadPoolConfigBuilder {
-
-        private String pool;
-
-        private boolean semaphoreIsolation = false;
 
         private int concurrency = Runtime.getRuntime().availableProcessors();
 
@@ -70,6 +51,5 @@ public class ThreadPoolConfig {
 
         private int dynamicRequestQueueSize = Runtime.getRuntime().availableProcessors() * 2;
 
-        private int timeout = 1000;
     }
 }

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -33,9 +33,7 @@ public class HystrixConfigurationFactory {
     }
 
     public static void init(final HystrixConfig config) {
-        if (factory == null) {
-            factory = new HystrixConfigurationFactory(config);
-        }
+        factory = new HystrixConfigurationFactory(config);
         factory.setup();
     }
 
@@ -252,7 +250,6 @@ public class HystrixConfigurationFactory {
     private void configureProperty(String property, boolean value) {
         ConfigurationManager.getConfigInstance().setProperty(property, value);
     }
-    
 
     public static HystrixCommand.Setter getCommandConfiguration(final String key) {
         if (factory == null) throw new IllegalStateException("Factory not initialized");
@@ -260,5 +257,13 @@ public class HystrixConfigurationFactory {
             factory.registerCommandProperties(key);
         }
         return factory.commandCache.get(key);
+    }
+
+    public static ConcurrentHashMap<String, HystrixCommand.Setter> getCommandCache() {
+        return factory.commandCache;
+    }
+
+    public static ConcurrentHashMap<String, HystrixThreadPoolProperties.Setter> getPoolCache() {
+        return factory.poolCache;
     }
 }

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -1,18 +1,25 @@
 package com.hystrix.configurator.core;
 
-import com.hystrix.configurator.config.*;
+import com.hystrix.configurator.config.HystrixCommandConfig;
+import com.hystrix.configurator.config.HystrixConfig;
+import com.hystrix.configurator.config.HystrixDefaultConfig;
+import com.hystrix.configurator.config.ThreadPoolConfig;
 import com.netflix.config.ConfigurationManager;
 import com.netflix.hystrix.*;
 import lombok.Getter;
-import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**
  * @author phaneesh
  */
+@Slf4j
 public class HystrixConfigurationFactory {
 
     private final HystrixConfig config;
@@ -29,134 +36,207 @@ public class HystrixConfigurationFactory {
     }
 
     public static void init(final HystrixConfig config) {
-        if(factory == null) {
+        if (factory == null) {
             factory = new HystrixConfigurationFactory(config);
         }
         factory.setup();
     }
 
     private void setup() {
-        if(config != null) {
-            defaultConfig = config.getDefaultConfig();
-            Map<String, HystrixCommandConfig> commandConfigMap = config.getCommands().stream().collect(Collectors.toMap(HystrixCommandConfig::getName, (c) -> c));
-            commandConfigMap.forEach( (k, v) -> {
-                if(v.getCircuitBreaker() == null)
-                    v.setCircuitBreaker(defaultConfig.getCircuitBreaker());
-                if(v.getThreadPool() == null)
-                    v.setThreadPool(defaultConfig.getThreadPool());
-                if(v.getMetrics() == null) {
-                    v.setMetrics(defaultConfig.getMetrics());
-                }
+        if (config == null) {
+            return;
+        }
+
+        validateUniquePools(config);
+        validateUniqueCommands(config);
+        defaultConfig = config.getDefaultConfig();
+
+        registerDefaultProperties(defaultConfig);
+
+        Map<String, ThreadPoolConfig> poolConfigs = new HashMap<>();
+        if (config.getPools() != null) {
+            config.getPools().forEach(pool -> {
+                poolConfigs.put(pool.getPool(), pool);
+                registerPoolProperties(pool);
+                log.info("registered pool: {}", pool);
             });
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
+        }
 
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.strategy", defaultConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.thread.timeoutInMilliseconds", defaultConfig.getThreadPool().getTimeout());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.timeout.enabled", true);
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.interruptOnTimeout", true);
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests", defaultConfig.getThreadPool().getConcurrency());
+        hystrixConfigCache = new ConcurrentHashMap<>();
+        config.getCommands()
+                .forEach(commandConfig -> {
+                    if (commandConfig.getCircuitBreaker() == null) {
+                        commandConfig.setCircuitBreaker(defaultConfig.getCircuitBreaker());
+                    }
+                    if (commandConfig.getMetrics() == null) {
+                        commandConfig.setMetrics(defaultConfig.getMetrics());
+                    }
+                    if (commandConfig.getThreadPool() == null) {
+                        commandConfig.setThreadPool(defaultConfig.getThreadPool());
+                    }
+                    registerCommand(defaultConfig, poolConfigs, commandConfig);
+                    log.info("registered command: {}", commandConfig.getName());
+                });
+    }
 
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.enabled", true);
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.requestVolumeThreshold", defaultConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.errorThresholdPercentage", defaultConfig.getCircuitBreaker().getErrorThreshold());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds", defaultConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
+    private void registerDefaultProperties(HystrixDefaultConfig defaultConfig) {
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
 
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingStats.timeInMilliseconds", defaultConfig.getMetrics().getStatsTimeInMillis());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingStats.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.enabled", true);
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.timeInMilliseconds", defaultConfig.getMetrics().getPercentileTimeInMillis());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.bucketSize", defaultConfig.getMetrics().getPercentileBucketSize());
-            ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds", defaultConfig.getMetrics().getHealthCheckInterval());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
 
-            commandConfigMap.values().stream().forEach(c -> {
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.coreSize", c.getName()), c.getThreadPool().getConcurrency());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.maxQueueSize", c.getName()), c.getThreadPool().getMaxRequestQueueSize());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.queueSizeRejectionThreshold", c.getName()), c.getThreadPool().getDynamicRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.strategy", defaultConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.thread.timeoutInMilliseconds", defaultConfig.getThreadPool().getTimeout());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.timeout.enabled", true);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.interruptOnTimeout", true);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests", defaultConfig.getThreadPool().getConcurrency());
 
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.strategy", c.getName()), c.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.thread.timeoutInMilliseconds", c.getName()), c.getThreadPool().getTimeout());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.timeout.enabled", c.getName()), true);
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.thread.interruptOnTimeout", c.getName()), true);
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.semaphore.maxConcurrentRequests", c.getName()), c.getThreadPool().getConcurrency());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.enabled", true);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.requestVolumeThreshold", defaultConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.errorThresholdPercentage", defaultConfig.getCircuitBreaker().getErrorThreshold());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds", defaultConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
 
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.enabled", c.getName()), true);
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.requestVolumeThreshold", c.getName()), c.getCircuitBreaker().getAcceptableFailuresInWindow());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.errorThresholdPercentage", c.getName()), c.getCircuitBreaker().getErrorThreshold());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.sleepWindowInMilliseconds", c.getName()), c.getCircuitBreaker().getWaitTimeBeforeRetry());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingStats.timeInMilliseconds", defaultConfig.getMetrics().getStatsTimeInMillis());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingStats.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.enabled", true);
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.timeInMilliseconds", defaultConfig.getMetrics().getPercentileTimeInMillis());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.bucketSize", defaultConfig.getMetrics().getPercentileBucketSize());
+        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds", defaultConfig.getMetrics().getHealthCheckInterval());
+    }
 
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingStats.timeInMilliseconds", c.getName()), c.getMetrics().getStatsTimeInMillis());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingStats.numBuckets", c.getName()), c.getMetrics().getNumBucketSize());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.enabled", c.getName()), true);
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.timeInMilliseconds", c.getName()), c.getMetrics().getPercentileTimeInMillis());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.numBuckets", c.getName()), c.getMetrics().getNumBucketSize());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.bucketSize", c.getName()), c.getMetrics().getPercentileBucketSize());
-                ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.healthSnapshot.intervalInMilliseconds", c.getName()), c.getMetrics().getHealthCheckInterval());
-            });
+    private void registerPoolProperties(ThreadPoolConfig pool) {
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.threadpool.%s.coreSize", pool.getPool()), pool.getConcurrency());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.threadpool.%s.maxQueueSize", pool.getPool()), pool.getMaxRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.threadpool.%s.queueSizeRejectionThreshold", pool.getPool()), pool.getDynamicRequestQueueSize());
+    }
 
-            val mapData = commandConfigMap.values().stream().collect(Collectors.toMap(HystrixCommandConfig::getName, (c) ->
-                    HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(c.getName()))
-                            .andCommandKey(HystrixCommandKey.Factory.asKey(c.getName()))
-                            .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(c.getName()))
-                            .andCommandPropertiesDefaults(
-                                    HystrixCommandProperties.Setter()
-                                            .withExecutionIsolationStrategy( c.getThreadPool().isSemaphoreIsolation() ? HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE: HystrixCommandProperties.ExecutionIsolationStrategy.THREAD)
-                                            .withExecutionIsolationSemaphoreMaxConcurrentRequests(c.getThreadPool().getConcurrency())
-                                            .withFallbackIsolationSemaphoreMaxConcurrentRequests(c.getThreadPool().getConcurrency())
-                                            .withFallbackEnabled(c.isFallbackEnabled())
-                                            .withCircuitBreakerErrorThresholdPercentage(c.getCircuitBreaker().getErrorThreshold())
-                                            .withCircuitBreakerRequestVolumeThreshold(c.getCircuitBreaker().getAcceptableFailuresInWindow())
-                                            .withCircuitBreakerSleepWindowInMilliseconds(c.getCircuitBreaker().getWaitTimeBeforeRetry())
-                                            .withExecutionTimeoutInMilliseconds(c.getThreadPool().getTimeout())
-                                            .withMetricsHealthSnapshotIntervalInMilliseconds(c.getMetrics().getHealthCheckInterval())
-                                            .withMetricsRollingPercentileBucketSize(c.getMetrics().getPercentileBucketSize())
-                                            .withMetricsRollingPercentileWindowInMilliseconds(c.getMetrics().getPercentileTimeInMillis())
-                            )
-                            .andThreadPoolPropertiesDefaults(
-                                    HystrixThreadPoolProperties.Setter()
-                                            .withCoreSize(c.getThreadPool().getConcurrency())
-                                            .withMaxQueueSize(c.getThreadPool().getMaxRequestQueueSize())
-                                            .withQueueSizeRejectionThreshold(c.getThreadPool().getDynamicRequestQueueSize())
-                                            .withMetricsRollingStatisticalWindowBuckets(c.getMetrics().getNumBucketSize())
-                                            .withMetricsRollingStatisticalWindowInMilliseconds(c.getMetrics().getStatsTimeInMillis())
-                            )
+    private void registerCommand(HystrixDefaultConfig defaultConfig,
+                                 Map<String, ThreadPoolConfig> poolConfigs,
+                                 HystrixCommandConfig commandConfig) {
+        // First check if a specific pool needs to be used here
+        String pool = commandConfig.getThreadPool() != null ? commandConfig.getThreadPool().getPool() : null;
+        if (pool == null || defaultConfig.getThreadPool().getPool().equalsIgnoreCase(pool)) {
+            pool = defaultConfig.getThreadPool().getPool();
+            log.info("using pool: default for command: {}", commandConfig.getName());
+        } else {
+            if (!poolConfigs.containsKey(pool)) {
+                log.warn("unknown pool: {} for command: {} using pool: default", pool, commandConfig.getName());
+                pool = defaultConfig.getThreadPool().getPool();
+            } else {
+                log.info("using pool: {} for command: {}", pool, commandConfig.getName());
+            }
+        }
+
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.coreSize", commandConfig.getName()), commandConfig.getThreadPool().getConcurrency());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.maxQueueSize", commandConfig.getName()), commandConfig.getThreadPool().getMaxRequestQueueSize());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.queueSizeRejectionThreshold", commandConfig.getName()), commandConfig.getThreadPool().getDynamicRequestQueueSize());
+
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.strategy", commandConfig.getName()), commandConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.thread.timeoutInMilliseconds", commandConfig.getName()), commandConfig.getThreadPool().getTimeout());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.timeout.enabled", commandConfig.getName()), true);
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.thread.interruptOnTimeout", commandConfig.getName()), true);
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.semaphore.maxConcurrentRequests", commandConfig.getName()), commandConfig.getThreadPool().getConcurrency());
+
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.enabled", commandConfig.getName()), true);
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.requestVolumeThreshold", commandConfig.getName()), commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.errorThresholdPercentage", commandConfig.getName()), commandConfig.getCircuitBreaker().getErrorThreshold());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.sleepWindowInMilliseconds", commandConfig.getName()), commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
+
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingStats.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getStatsTimeInMillis());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingStats.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.enabled", commandConfig.getName()), true);
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getPercentileTimeInMillis());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.bucketSize", commandConfig.getName()), commandConfig.getMetrics().getPercentileBucketSize());
+        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.healthSnapshot.intervalInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getHealthCheckInterval());
+
+        // Register in cache
+        hystrixConfigCache.put(commandConfig.getName(), HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(commandConfig.getName()))
+                .andCommandKey(HystrixCommandKey.Factory.asKey(commandConfig.getName()))
+                .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(pool))
+                .andCommandPropertiesDefaults(
+                        HystrixCommandProperties.Setter()
+                                .withExecutionIsolationStrategy(commandConfig.getThreadPool().isSemaphoreIsolation() ? HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE : HystrixCommandProperties.ExecutionIsolationStrategy.THREAD)
+                                .withExecutionIsolationSemaphoreMaxConcurrentRequests(commandConfig.getThreadPool().getConcurrency())
+                                .withFallbackIsolationSemaphoreMaxConcurrentRequests(commandConfig.getThreadPool().getConcurrency())
+                                .withFallbackEnabled(commandConfig.isFallbackEnabled())
+                                .withCircuitBreakerErrorThresholdPercentage(commandConfig.getCircuitBreaker().getErrorThreshold())
+                                .withCircuitBreakerRequestVolumeThreshold(commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow())
+                                .withCircuitBreakerSleepWindowInMilliseconds(commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry())
+                                .withExecutionTimeoutInMilliseconds(commandConfig.getThreadPool().getTimeout())
+                                .withMetricsHealthSnapshotIntervalInMilliseconds(commandConfig.getMetrics().getHealthCheckInterval())
+                                .withMetricsRollingPercentileBucketSize(commandConfig.getMetrics().getPercentileBucketSize())
+                                .withMetricsRollingPercentileWindowInMilliseconds(commandConfig.getMetrics().getPercentileTimeInMillis())
+                )
+                .andThreadPoolPropertiesDefaults(
+                        HystrixThreadPoolProperties.Setter()
+                                .withCoreSize(commandConfig.getThreadPool().getConcurrency())
+                                .withMaxQueueSize(commandConfig.getThreadPool().getMaxRequestQueueSize())
+                                .withQueueSizeRejectionThreshold(commandConfig.getThreadPool().getDynamicRequestQueueSize())
+                                .withMetricsRollingStatisticalWindowBuckets(commandConfig.getMetrics().getNumBucketSize())
+                                .withMetricsRollingStatisticalWindowInMilliseconds(commandConfig.getMetrics().getStatsTimeInMillis())
                 ));
-            hystrixConfigCache = new ConcurrentHashMap<>();
-            hystrixConfigCache.putAll(mapData);
+    }
+
+    private void registerCommand(String command) {
+        HystrixCommandConfig commandConfig = HystrixCommandConfig.builder()
+                .name(command)
+                .threadPool(defaultConfig.getThreadPool())
+                .metrics(defaultConfig.getMetrics())
+                .circuitBreaker(defaultConfig.getCircuitBreaker())
+                .fallbackEnabled(false)
+                .build();
+        registerCommand(defaultConfig, Collections.emptyMap(), commandConfig);
+    }
+
+    private void validateUniqueCommands(HystrixConfig config) {
+        if (config.getPools() == null) {
+            return;
+        }
+
+        AtomicBoolean duplicatePresent = new AtomicBoolean(false);
+        config.getCommands().stream()
+                .collect(Collectors.groupingBy(HystrixCommandConfig::getName, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .filter(x -> x.getValue() > 1)
+                .forEach(x -> {
+                    log.warn("Duplicate command configuration command:{}", x.getKey());
+                    duplicatePresent.set(true);
+                });
+        if (duplicatePresent.get()) {
+            throw new RuntimeException("Duplicate Command Configurations");
+        }
+    }
+
+    private void validateUniquePools(HystrixConfig config) {
+        if (config.getPools() == null) {
+            return;
+        }
+
+        AtomicBoolean duplicatePresent = new AtomicBoolean(false);
+        config.getPools().stream()
+                .collect(Collectors.groupingBy(ThreadPoolConfig::getPool, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .filter(x -> x.getValue() > 1)
+                .forEach(x -> {
+                    log.warn("Duplicate pool configuration pool:{}", x.getKey());
+                    duplicatePresent.set(true);
+                });
+        if (duplicatePresent.get()) {
+            throw new RuntimeException("Duplicate Pool Configurations");
         }
     }
 
     public static HystrixCommand.Setter getCommandConfiguration(final String key) {
-        if(factory == null) throw new IllegalStateException("Factory not initialized");
-        if(!factory.hystrixConfigCache.containsKey(key)) {
-            factory.hystrixConfigCache.putIfAbsent(key,
-            HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(key))
-                    .andCommandKey(HystrixCommandKey.Factory.asKey(key))
-                    .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(key))
-                    .andCommandPropertiesDefaults(
-                            HystrixCommandProperties.Setter()
-                                    .withExecutionIsolationStrategy(HystrixCommandProperties.ExecutionIsolationStrategy.THREAD)
-                                    .withExecutionIsolationSemaphoreMaxConcurrentRequests(factory.getDefaultConfig().getThreadPool().getConcurrency())
-                                    .withFallbackIsolationSemaphoreMaxConcurrentRequests(factory.getDefaultConfig().getThreadPool().getConcurrency())
-                                    .withFallbackEnabled(false)
-                                    .withCircuitBreakerErrorThresholdPercentage(factory.getDefaultConfig().getCircuitBreaker().getErrorThreshold())
-                                    .withCircuitBreakerRequestVolumeThreshold(factory.getDefaultConfig().getCircuitBreaker().getAcceptableFailuresInWindow())
-                                    .withCircuitBreakerSleepWindowInMilliseconds(factory.getDefaultConfig().getCircuitBreaker().getWaitTimeBeforeRetry())
-                                    .withExecutionTimeoutInMilliseconds(factory.getDefaultConfig().getThreadPool().getTimeout())
-                                    .withMetricsHealthSnapshotIntervalInMilliseconds(factory.getDefaultConfig().getMetrics().getHealthCheckInterval())
-                                    .withMetricsRollingPercentileBucketSize(factory.getDefaultConfig().getMetrics().getPercentileBucketSize())
-                                    .withMetricsRollingPercentileWindowInMilliseconds(factory.getDefaultConfig().getMetrics().getPercentileTimeInMillis())
-                    )
-                    .andThreadPoolPropertiesDefaults(
-                            HystrixThreadPoolProperties.Setter()
-                                    .withCoreSize(factory.getDefaultConfig().getThreadPool().getConcurrency())
-                                    .withMaxQueueSize(factory.getDefaultConfig().getThreadPool().getMaxRequestQueueSize())
-                                    .withQueueSizeRejectionThreshold(factory.getDefaultConfig().getThreadPool().getDynamicRequestQueueSize())
-                                    .withMetricsRollingStatisticalWindowBuckets(factory.getDefaultConfig().getMetrics().getNumBucketSize())
-                                    .withMetricsRollingStatisticalWindowInMilliseconds(factory.getDefaultConfig().getMetrics().getStatsTimeInMillis())
-                    ));
+        if (factory == null) throw new IllegalStateException("Factory not initialized");
+        if (!factory.hystrixConfigCache.containsKey(key)) {
+            factory.registerCommand(key);
         }
         return factory.hystrixConfigCache.get(key);
     }

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -8,6 +8,7 @@ import com.netflix.config.ConfigurationManager;
 import com.netflix.hystrix.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,7 +28,9 @@ public class HystrixConfigurationFactory {
     @Getter
     private HystrixDefaultConfig defaultConfig;
 
-    private ConcurrentHashMap<String, HystrixCommand.Setter> hystrixConfigCache;
+    private ConcurrentHashMap<String, HystrixCommand.Setter> commandCache;
+
+    private ConcurrentHashMap<String, HystrixThreadPoolProperties.Setter> poolCache;
 
     private static HystrixConfigurationFactory factory;
 
@@ -43,10 +46,6 @@ public class HystrixConfigurationFactory {
     }
 
     private void setup() {
-        if (config == null) {
-            return;
-        }
-
         validateUniquePools(config);
         validateUniqueCommands(config);
         defaultConfig = config.getDefaultConfig();
@@ -57,12 +56,14 @@ public class HystrixConfigurationFactory {
         if (config.getPools() != null) {
             config.getPools().forEach(pool -> {
                 poolConfigs.put(pool.getPool(), pool);
-                registerPoolProperties(pool);
+                registerThreadPoolProperties(pool);
                 log.info("registered pool: {}", pool);
             });
         }
 
-        hystrixConfigCache = new ConcurrentHashMap<>();
+        commandCache = new ConcurrentHashMap<>();
+        poolCache = new ConcurrentHashMap<>();
+
         config.getCommands()
                 .forEach(commandConfig -> {
                     if (commandConfig.getCircuitBreaker() == null) {
@@ -74,115 +75,133 @@ public class HystrixConfigurationFactory {
                     if (commandConfig.getThreadPool() == null) {
                         commandConfig.setThreadPool(defaultConfig.getThreadPool());
                     }
-                    registerCommand(defaultConfig, poolConfigs, commandConfig);
+                    registerCommandProperties(defaultConfig, poolConfigs, commandConfig);
                     log.info("registered command: {}", commandConfig.getName());
                 });
     }
 
     private void registerDefaultProperties(HystrixDefaultConfig defaultConfig) {
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
+        configureProperty("hystrix.threadpool.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
+        configureProperty("hystrix.threadpool.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
+        configureProperty("hystrix.threadpool.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
 
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
+        configureProperty("hystrix.command.default.coreSize", defaultConfig.getThreadPool().getConcurrency());
+        configureProperty("hystrix.command.default.maxQueueSize", defaultConfig.getThreadPool().getMaxRequestQueueSize());
+        configureProperty("hystrix.command.default.queueSizeRejectionThreshold", defaultConfig.getThreadPool().getDynamicRequestQueueSize());
 
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.strategy", defaultConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.thread.timeoutInMilliseconds", defaultConfig.getThreadPool().getTimeout());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.timeout.enabled", true);
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.thread.interruptOnTimeout", true);
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests", defaultConfig.getThreadPool().getConcurrency());
+        configureProperty("hystrix.command.default.execution.isolation.strategy", defaultConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
+        configureProperty("hystrix.command.default.execution.thread.timeoutInMilliseconds", defaultConfig.getThreadPool().getTimeout());
+        configureProperty("hystrix.command.default.execution.timeout.enabled", true);
+        configureProperty("hystrix.command.default.execution.isolation.thread.interruptOnTimeout", true);
+        configureProperty("hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests", defaultConfig.getThreadPool().getConcurrency());
 
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.enabled", true);
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.requestVolumeThreshold", defaultConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.errorThresholdPercentage", defaultConfig.getCircuitBreaker().getErrorThreshold());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds", defaultConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
+        configureProperty("hystrix.command.default.circuitBreaker.enabled", true);
+        configureProperty("hystrix.command.default.circuitBreaker.requestVolumeThreshold", defaultConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
+        configureProperty("hystrix.command.default.circuitBreaker.errorThresholdPercentage", defaultConfig.getCircuitBreaker().getErrorThreshold());
+        configureProperty("hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds", defaultConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
 
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingStats.timeInMilliseconds", defaultConfig.getMetrics().getStatsTimeInMillis());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingStats.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.enabled", true);
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.timeInMilliseconds", defaultConfig.getMetrics().getPercentileTimeInMillis());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.rollingPercentile.bucketSize", defaultConfig.getMetrics().getPercentileBucketSize());
-        ConfigurationManager.getConfigInstance().setProperty("hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds", defaultConfig.getMetrics().getHealthCheckInterval());
+        configureProperty("hystrix.command.default.metrics.rollingStats.timeInMilliseconds", defaultConfig.getMetrics().getStatsTimeInMillis());
+        configureProperty("hystrix.command.default.metrics.rollingStats.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
+        configureProperty("hystrix.command.default.metrics.rollingPercentile.enabled", true);
+        configureProperty("hystrix.command.default.metrics.rollingPercentile.timeInMilliseconds", defaultConfig.getMetrics().getPercentileTimeInMillis());
+        configureProperty("hystrix.command.default.metrics.rollingPercentile.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
+        configureProperty("hystrix.command.default.metrics.rollingPercentile.bucketSize", defaultConfig.getMetrics().getPercentileBucketSize());
+        configureProperty("hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds", defaultConfig.getMetrics().getHealthCheckInterval());
     }
 
-    private void registerPoolProperties(ThreadPoolConfig pool) {
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.threadpool.%s.coreSize", pool.getPool()), pool.getConcurrency());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.threadpool.%s.maxQueueSize", pool.getPool()), pool.getMaxRequestQueueSize());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.threadpool.%s.queueSizeRejectionThreshold", pool.getPool()), pool.getDynamicRequestQueueSize());
+    private void registerThreadPoolProperties(ThreadPoolConfig pool) {
+
     }
 
-    private void registerCommand(HystrixDefaultConfig defaultConfig,
-                                 Map<String, ThreadPoolConfig> poolConfigs,
-                                 HystrixCommandConfig commandConfig) {
-        // First check if a specific pool needs to be used here
-        String pool = commandConfig.getThreadPool() != null ? commandConfig.getThreadPool().getPool() : null;
-        if (pool == null || defaultConfig.getThreadPool().getPool().equalsIgnoreCase(pool)) {
-            pool = defaultConfig.getThreadPool().getPool();
-            log.info("using pool: default for command: {}", commandConfig.getName());
-        } else {
-            if (!poolConfigs.containsKey(pool)) {
-                log.warn("unknown pool: {} for command: {} using pool: default", pool, commandConfig.getName());
-                pool = defaultConfig.getThreadPool().getPool();
-            } else {
-                log.info("using pool: {} for command: {}", pool, commandConfig.getName());
+    private void registerCommandProperties(HystrixDefaultConfig defaultConfig,
+                                           Map<String, ThreadPoolConfig> poolConfigs,
+                                           HystrixCommandConfig commandConfig) {
+        val command = commandConfig.getName();
+
+        configureProperty(String.format("hystrix.command.%s.execution.isolation.strategy", command), commandConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
+        configureProperty(String.format("hystrix.command.%s.execution.thread.timeoutInMilliseconds", command), commandConfig.getThreadPool().getTimeout());
+        configureProperty(String.format("hystrix.command.%s.execution.timeout.enabled", command), true);
+        configureProperty(String.format("hystrix.command.%s.execution.isolation.thread.interruptOnTimeout", command), true);
+        configureProperty(String.format("hystrix.command.%s.execution.isolation.semaphore.maxConcurrentRequests", command), commandConfig.getThreadPool().getConcurrency());
+
+        configureProperty(String.format("hystrix.command.%s.circuitBreaker.enabled", commandConfig.getName()), true);
+        configureProperty(String.format("hystrix.command.%s.circuitBreaker.requestVolumeThreshold", commandConfig.getName()), commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
+        configureProperty(String.format("hystrix.command.%s.circuitBreaker.errorThresholdPercentage", commandConfig.getName()), commandConfig.getCircuitBreaker().getErrorThreshold());
+        configureProperty(String.format("hystrix.command.%s.circuitBreaker.sleepWindowInMilliseconds", commandConfig.getName()), commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
+
+        configureProperty(String.format("hystrix.command.%s.metrics.rollingStats.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getStatsTimeInMillis());
+        configureProperty(String.format("hystrix.command.%s.metrics.rollingStats.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
+        configureProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.enabled", commandConfig.getName()), true);
+        configureProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getPercentileTimeInMillis());
+        configureProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
+        configureProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.bucketSize", commandConfig.getName()), commandConfig.getMetrics().getPercentileBucketSize());
+        configureProperty(String.format("hystrix.command.%s.metrics.healthSnapshot.intervalInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getHealthCheckInterval());
+
+        val commandProperties = HystrixCommandProperties.Setter()
+                .withExecutionIsolationStrategy(commandConfig.getThreadPool().isSemaphoreIsolation() ? HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE : HystrixCommandProperties.ExecutionIsolationStrategy.THREAD)
+                .withExecutionIsolationSemaphoreMaxConcurrentRequests(commandConfig.getThreadPool().getConcurrency())
+                .withFallbackIsolationSemaphoreMaxConcurrentRequests(commandConfig.getThreadPool().getConcurrency())
+                .withFallbackEnabled(commandConfig.isFallbackEnabled())
+                .withCircuitBreakerErrorThresholdPercentage(commandConfig.getCircuitBreaker().getErrorThreshold())
+                .withCircuitBreakerRequestVolumeThreshold(commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow())
+                .withCircuitBreakerSleepWindowInMilliseconds(commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry())
+                .withExecutionTimeoutInMilliseconds(commandConfig.getThreadPool().getTimeout())
+                .withMetricsHealthSnapshotIntervalInMilliseconds(commandConfig.getMetrics().getHealthCheckInterval())
+                .withMetricsRollingPercentileBucketSize(commandConfig.getMetrics().getPercentileBucketSize())
+                .withMetricsRollingPercentileWindowInMilliseconds(commandConfig.getMetrics().getPercentileTimeInMillis());
+
+        HystrixCommand.Setter commandConfiguration = HystrixCommand.Setter
+                .withGroupKey(HystrixCommandGroupKey.Factory.asKey(commandConfig.getName()))
+                .andCommandKey(HystrixCommandKey.Factory.asKey(commandConfig.getName()))
+                .andCommandPropertiesDefaults(commandProperties);
+
+        if (!commandConfig.getThreadPool().isSemaphoreIsolation()) {
+            val explicitPool = commandConfig.getThreadPool() != null ? commandConfig.getThreadPool().getPool() : null;
+            /*
+                If an explicit pool is defined, it should be present in pool list otherwise
+                a pool with name same as command would be defined
+            */
+            if (explicitPool != null && !poolConfigs.containsKey(explicitPool)) {
+                val message = String.format("Undefined explicit pool [%s] used in command [%s]", explicitPool, command);
+                log.error(message);
+                throw new RuntimeException(message);
             }
+            val effectivePool = explicitPool != null ? explicitPool : command;
+            val poolConfig = explicitPool != null ? poolConfigs.get(explicitPool) : defaultConfig.getThreadPool();
+            val poolPrefix = explicitPool != null ? "pool" : "com";
+            val pool = String.format("%s_%s", poolPrefix, effectivePool);
+            log.info("using pool: {} with prefix: {} for command: {}", effectivePool, poolPrefix, command);
+
+            val poolConfiguration = getOrCreateThreadPool(pool, defaultConfig, poolConfig);
+            commandConfiguration
+                    .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(pool))
+                    .andThreadPoolPropertiesDefaults(poolConfiguration);
+        }
+        commandCache.put(commandConfig.getName(), commandConfiguration);
+    }
+
+    private HystrixThreadPoolProperties.Setter getOrCreateThreadPool(String pool,
+                                                                     HystrixDefaultConfig defaultConfig,
+                                                                     ThreadPoolConfig poolConfig) {
+        if (poolCache.containsKey(pool)) {
+            return poolCache.get(pool);
         }
 
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.coreSize", commandConfig.getName()), commandConfig.getThreadPool().getConcurrency());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.maxQueueSize", commandConfig.getName()), commandConfig.getThreadPool().getMaxRequestQueueSize());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.queueSizeRejectionThreshold", commandConfig.getName()), commandConfig.getThreadPool().getDynamicRequestQueueSize());
+        configureProperty(String.format("hystrix.threadpool.%s.coreSize", pool), poolConfig.getConcurrency());
+        configureProperty(String.format("hystrix.threadpool.%s.maximumSize", pool), poolConfig.getConcurrency());
+        configureProperty(String.format("hystrix.threadpool.%s.maxQueueSize", pool), poolConfig.getMaxRequestQueueSize());
+        configureProperty(String.format("hystrix.threadpool.%s.queueSizeRejectionThreshold", pool), poolConfig.getDynamicRequestQueueSize());
 
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.strategy", commandConfig.getName()), commandConfig.getThreadPool().isSemaphoreIsolation() ? "SEMAPHORE" : "THREAD");
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.thread.timeoutInMilliseconds", commandConfig.getName()), commandConfig.getThreadPool().getTimeout());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.timeout.enabled", commandConfig.getName()), true);
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.thread.interruptOnTimeout", commandConfig.getName()), true);
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.execution.isolation.semaphore.maxConcurrentRequests", commandConfig.getName()), commandConfig.getThreadPool().getConcurrency());
-
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.enabled", commandConfig.getName()), true);
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.requestVolumeThreshold", commandConfig.getName()), commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.errorThresholdPercentage", commandConfig.getName()), commandConfig.getCircuitBreaker().getErrorThreshold());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.circuitBreaker.sleepWindowInMilliseconds", commandConfig.getName()), commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
-
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingStats.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getStatsTimeInMillis());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingStats.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.enabled", commandConfig.getName()), true);
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getPercentileTimeInMillis());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.rollingPercentile.bucketSize", commandConfig.getName()), commandConfig.getMetrics().getPercentileBucketSize());
-        ConfigurationManager.getConfigInstance().setProperty(String.format("hystrix.command.%s.metrics.healthSnapshot.intervalInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getHealthCheckInterval());
-
-        // Register in cache
-        hystrixConfigCache.put(commandConfig.getName(), HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(commandConfig.getName()))
-                .andCommandKey(HystrixCommandKey.Factory.asKey(commandConfig.getName()))
-                .andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(pool))
-                .andCommandPropertiesDefaults(
-                        HystrixCommandProperties.Setter()
-                                .withExecutionIsolationStrategy(commandConfig.getThreadPool().isSemaphoreIsolation() ? HystrixCommandProperties.ExecutionIsolationStrategy.SEMAPHORE : HystrixCommandProperties.ExecutionIsolationStrategy.THREAD)
-                                .withExecutionIsolationSemaphoreMaxConcurrentRequests(commandConfig.getThreadPool().getConcurrency())
-                                .withFallbackIsolationSemaphoreMaxConcurrentRequests(commandConfig.getThreadPool().getConcurrency())
-                                .withFallbackEnabled(commandConfig.isFallbackEnabled())
-                                .withCircuitBreakerErrorThresholdPercentage(commandConfig.getCircuitBreaker().getErrorThreshold())
-                                .withCircuitBreakerRequestVolumeThreshold(commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow())
-                                .withCircuitBreakerSleepWindowInMilliseconds(commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry())
-                                .withExecutionTimeoutInMilliseconds(commandConfig.getThreadPool().getTimeout())
-                                .withMetricsHealthSnapshotIntervalInMilliseconds(commandConfig.getMetrics().getHealthCheckInterval())
-                                .withMetricsRollingPercentileBucketSize(commandConfig.getMetrics().getPercentileBucketSize())
-                                .withMetricsRollingPercentileWindowInMilliseconds(commandConfig.getMetrics().getPercentileTimeInMillis())
-                )
-                .andThreadPoolPropertiesDefaults(
-                        HystrixThreadPoolProperties.Setter()
-                                .withCoreSize(commandConfig.getThreadPool().getConcurrency())
-                                .withMaxQueueSize(commandConfig.getThreadPool().getMaxRequestQueueSize())
-                                .withQueueSizeRejectionThreshold(commandConfig.getThreadPool().getDynamicRequestQueueSize())
-                                .withMetricsRollingStatisticalWindowBuckets(commandConfig.getMetrics().getNumBucketSize())
-                                .withMetricsRollingStatisticalWindowInMilliseconds(commandConfig.getMetrics().getStatsTimeInMillis())
-                ));
+        HystrixThreadPoolProperties.Setter poolHystrixSetter = HystrixThreadPoolProperties.Setter()
+                .withCoreSize(poolConfig.getConcurrency())
+                .withMaximumSize(poolConfig.getConcurrency())
+                .withMaxQueueSize(poolConfig.getMaxRequestQueueSize())
+                .withQueueSizeRejectionThreshold(poolConfig.getDynamicRequestQueueSize());
+        poolCache.put(pool, poolHystrixSetter);
+        return poolHystrixSetter;
     }
 
-    private void registerCommand(String command) {
+    private void registerCommandProperties(String command) {
         HystrixCommandConfig commandConfig = HystrixCommandConfig.builder()
                 .name(command)
                 .threadPool(defaultConfig.getThreadPool())
@@ -190,11 +209,11 @@ public class HystrixConfigurationFactory {
                 .circuitBreaker(defaultConfig.getCircuitBreaker())
                 .fallbackEnabled(false)
                 .build();
-        registerCommand(defaultConfig, Collections.emptyMap(), commandConfig);
+        registerCommandProperties(defaultConfig, Collections.emptyMap(), commandConfig);
     }
 
     private void validateUniqueCommands(HystrixConfig config) {
-        if (config.getPools() == null) {
+        if (config.getCommands() == null) {
             return;
         }
 
@@ -205,11 +224,11 @@ public class HystrixConfigurationFactory {
                 .stream()
                 .filter(x -> x.getValue() > 1)
                 .forEach(x -> {
-                    log.warn("Duplicate command configuration command:{}", x.getKey());
+                    log.warn("Duplicate command configuration for command [{}]", x.getKey());
                     duplicatePresent.set(true);
                 });
         if (duplicatePresent.get()) {
-            throw new RuntimeException("Duplicate Command Configurations");
+            throw new RuntimeException("Duplicate Hystrix Command Configurations");
         }
     }
 
@@ -229,15 +248,28 @@ public class HystrixConfigurationFactory {
                     duplicatePresent.set(true);
                 });
         if (duplicatePresent.get()) {
-            throw new RuntimeException("Duplicate Pool Configurations");
+            throw new RuntimeException("Duplicate Hystrix Pool Configurations");
         }
     }
 
+    private void configureProperty(String property, int value) {
+        ConfigurationManager.getConfigInstance().setProperty(property, value);
+    }
+
+    private void configureProperty(String property, String value) {
+        ConfigurationManager.getConfigInstance().setProperty(property, value);
+    }
+
+    private void configureProperty(String property, boolean value) {
+        ConfigurationManager.getConfigInstance().setProperty(property, value);
+    }
+    
+
     public static HystrixCommand.Setter getCommandConfiguration(final String key) {
         if (factory == null) throw new IllegalStateException("Factory not initialized");
-        if (!factory.hystrixConfigCache.containsKey(key)) {
-            factory.registerCommand(key);
+        if (!factory.commandCache.containsKey(key)) {
+            factory.registerCommandProperties(key);
         }
-        return factory.hystrixConfigCache.get(key);
+        return factory.commandCache.get(key);
     }
 }

--- a/src/test/java/com/hystrix/configutator/HystrixConfigurationFactorySingleCommandTest.java
+++ b/src/test/java/com/hystrix/configutator/HystrixConfigurationFactorySingleCommandTest.java
@@ -49,7 +49,7 @@ public class HystrixConfigurationFactorySingleCommandTest {
     public void testCommand() throws ExecutionException, InterruptedException {
         SimpleTestCommand command = new SimpleTestCommand();
         String result = command.queue().get();
-        Assert.assertTrue(result.equals("Simple Test"));
+        Assert.assertEquals("Simple Test", result);
     }
 
     public static class SimpleTestCommand extends HystrixCommand<String> {


### PR DESCRIPTION
In current implementation, each hystrix command creates separate threadpool. This PR provides facility to create globally named threadpools which can then be used by individual commands if required. Configuration is completely backward compatible.

hystrix-core updated to 1.5.18

One breaking change - hystrix threadpool names have been suffixed with **global_** and **command_** in order to keep all pool names unique. This would change pool names in JMX metrics.
