### PR TITLE
Hystrix  dynamic config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,5 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.appform.core</groupId>
-            <artifactId>hystrix-function-wrapper</artifactId>
-            <version>1.1.8</version>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.hystrix</groupId>
     <artifactId>hystrix-configurator</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <packaging>jar</packaging>
 
     <name>hystrix-configurator</name>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <lombok.version>1.18.24</lombok.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <okhttp.version>4.9.0</okhttp.version>
     </properties>
 
     <dependencies>
@@ -80,6 +81,16 @@
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.appform.core</groupId>
+            <artifactId>hystrix-function-wrapper</artifactId>
+            <version>1.1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
         <lombok.version>1.18.24</lombok.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <okhttp.version>4.9.0</okhttp.version>
     </properties>
 
     <dependencies>
@@ -86,11 +85,6 @@
             <groupId>io.appform.core</groupId>
             <artifactId>hystrix-function-wrapper</artifactId>
             <version>1.1.8</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/hystrix/configurator/core/BaseCommand.java
+++ b/src/main/java/com/hystrix/configurator/core/BaseCommand.java
@@ -1,5 +1,6 @@
 package com.hystrix.configurator.core;
 
+import com.hystrix.configurator.config.HystrixCommandConfig;
 import com.netflix.hystrix.HystrixCommand;
 
 /**
@@ -9,6 +10,10 @@ public abstract class BaseCommand<T> extends HystrixCommand<T> {
 
     public BaseCommand(final String name) {
         super(HystrixConfigurationFactory.getCommandConfiguration(name));
+    }
+
+    public BaseCommand(final String name, final HystrixCommandConfig commandConfig) {
+        super(HystrixConfigurationFactory.getOrSetCommandConfiguration(name, commandConfig));
     }
 
 }

--- a/src/main/java/com/hystrix/configurator/core/BaseCommand.java
+++ b/src/main/java/com/hystrix/configurator/core/BaseCommand.java
@@ -13,7 +13,7 @@ public abstract class BaseCommand<T> extends HystrixCommand<T> {
     }
 
     public BaseCommand(final String name, final HystrixCommandConfig commandConfig) {
-        super(HystrixConfigurationFactory.getOrSetCommandConfiguration(name, commandConfig));
+        super(HystrixConfigurationFactory.updateOrCreateWithNewHystrixConfig(name, commandConfig));
     }
 
 }

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -290,14 +290,6 @@ public class HystrixConfigurationFactory {
         return factory.commandCache.get(key);
     }
 
-    public static HystrixCommand.Setter getOrSetCommandConfiguration(final String key, HystrixCommandConfig config) {
-        if (factory == null) throw new IllegalStateException("Factory not initialized");
-        if (!factory.commandCache.containsKey(key)) {
-            factory.registerCommandProperties(key, config);
-        }
-        return factory.commandCache.get(key);
-    }
-
     public static ConcurrentHashMap<String, HystrixCommand.Setter> getCommandCache() {
         return factory.commandCache;
     }
@@ -306,7 +298,7 @@ public class HystrixConfigurationFactory {
         return factory.poolCache;
     }
 
-    public static HystrixCommand.Setter updateWithNewHystrixConfig(final String key, HystrixCommandConfig commandConfig) {
+    public static HystrixCommand.Setter updateOrCreateWithNewHystrixConfig(final String key, HystrixCommandConfig commandConfig) {
         if (factory == null) throw new IllegalStateException("Factory not initialized");
         if (factory.commandCache.containsKey(key)) {
             factory.commandCache.remove(key);

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -119,6 +119,30 @@ public class HystrixConfigurationFactory {
         registerCommandProperties(defaultConfig, commandConfig);
     }
 
+
+    private void registerCommandProperties(String command, HystrixCommandConfig config) {
+        if (config.getCircuitBreaker() == null) {
+            config.setCircuitBreaker(defaultConfig.getCircuitBreaker());
+        }
+        if (config.getMetrics() == null) {
+            config.setMetrics(defaultConfig.getMetrics());
+        }
+        if (config.getThreadPool() == null) {
+            config.setThreadPool(defaultConfig.getThreadPool());
+        }
+
+        HystrixCommandConfig commandConfig = HystrixCommandConfig.builder()
+                .name(command)
+                .semaphoreIsolation(false)
+                .threadPool(config.getThreadPool())
+                .metrics(config.getMetrics())
+                .circuitBreaker(config.getCircuitBreaker())
+                .fallbackEnabled(false)
+                .build();
+        registerCommandProperties(defaultConfig, commandConfig);
+
+        log.info("registered command: {}", commandConfig.getName());
+    }
     private void registerCommandProperties(HystrixDefaultConfig defaultConfig, HystrixCommandConfig commandConfig) {
         val command = commandConfig.getName();
 
@@ -262,6 +286,14 @@ public class HystrixConfigurationFactory {
         if (factory == null) throw new IllegalStateException("Factory not initialized");
         if (!factory.commandCache.containsKey(key)) {
             factory.registerCommandProperties(key);
+        }
+        return factory.commandCache.get(key);
+    }
+
+    public static HystrixCommand.Setter getOrSetCommandConfiguration(final String key, HystrixCommandConfig config) {
+        if (factory == null) throw new IllegalStateException("Factory not initialized");
+        if (!factory.commandCache.containsKey(key)) {
+            factory.registerCommandProperties(key, config);
         }
         return factory.commandCache.get(key);
     }

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -305,4 +305,16 @@ public class HystrixConfigurationFactory {
     public static ConcurrentHashMap<String, HystrixThreadPoolProperties.Setter> getPoolCache() {
         return factory.poolCache;
     }
+
+    public static HystrixCommand.Setter updateWithNewHystrixConfig(final String key, HystrixCommandConfig commandConfig) {
+        if (factory == null) throw new IllegalStateException("Factory not initialized");
+        if (factory.commandCache.containsKey(key)) {
+            factory.commandCache.remove(key);
+        }
+        if (factory.poolCache.containsKey("command_" + key)) {
+            factory.poolCache.remove("command_" + key);
+        }
+        factory.registerCommandProperties(key, commandConfig);
+        return factory.commandCache.get(key);
+    }
 }

--- a/src/test/java/com/hystrix/configutator/HystrixConfigurationDynamicUpdateTest.java
+++ b/src/test/java/com/hystrix/configutator/HystrixConfigurationDynamicUpdateTest.java
@@ -20,24 +20,17 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class HystrixConfigurationDynamicUpdateTest {
 
-    private void changeTimeout() {
-        if (HystrixConfigurationFactory.getCommandCache().containsKey("TestCommand")) {
+    private void changeTimeout(String commandName) {
 
-            HystrixConfigurationFactory.getCommandCache().remove("TestCommand");
-            HystrixConfigurationFactory.getPoolCache().remove("command_TestCommand");
-
-            HystrixCommandConfig commandConfig1 = HystrixCommandConfig.builder()
-                    .name("TestCommand")
-                    .semaphoreIsolation(false)
-                    .threadPool(CommandThreadPoolConfig.builder().timeout(4000).build())
-                    .metrics(MetricsConfig.builder().build())
-                    .circuitBreaker(CircuitBreakerConfig.builder().build())
-                    .fallbackEnabled(false)
-                    .build();
-
-            HystrixConfigurationFactory.getOrSetCommandConfiguration("TestCommand", commandConfig1);
-            log.info("Works!!!!");
-        }
+        HystrixCommandConfig commandConfig = HystrixCommandConfig.builder()
+                .name("TestCommand")
+                .semaphoreIsolation(false)
+                .threadPool(CommandThreadPoolConfig.builder().timeout(4000).build())
+                .metrics(MetricsConfig.builder().build())
+                .circuitBreaker(CircuitBreakerConfig.builder().build())
+                .fallbackEnabled(false)
+                .build();
+        HystrixConfigurationFactory.updateWithNewHystrixConfig("TestCommand", commandConfig);
     }
 
 
@@ -57,7 +50,7 @@ public class HystrixConfigurationDynamicUpdateTest {
             String result = command3.queue().get();
             Assert.assertTrue(result.equals("Simple Test"));
         } catch (Exception e) {
-            changeTimeout();
+            changeTimeout("TestCommand");
             SimpleTestCommand command111 = new SimpleTestCommand(null);
             String result1 = command111.queue().get();
             Assert.assertTrue(result1.equals("Simple Test"));

--- a/src/test/java/com/hystrix/configutator/HystrixConfigurationDynamicUpdateTest.java
+++ b/src/test/java/com/hystrix/configutator/HystrixConfigurationDynamicUpdateTest.java
@@ -20,7 +20,16 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class HystrixConfigurationDynamicUpdateTest {
 
-    private void changeTimeout(String commandName) {
+    @Before
+    public void setup() {
+        HystrixConfigurationFactory.init(
+                HystrixConfig.builder()
+                        .defaultConfig(new HystrixDefaultConfig())
+                        .commands(Collections.singletonList(HystrixCommandConfig.builder().name("test").build()))
+                        .build());
+    }
+
+    private void changeTimeoutAndTest(String commandName) throws ExecutionException, InterruptedException {
 
         HystrixCommandConfig commandConfig = HystrixCommandConfig.builder()
                 .name("TestCommand")
@@ -30,7 +39,9 @@ public class HystrixConfigurationDynamicUpdateTest {
                 .circuitBreaker(CircuitBreakerConfig.builder().build())
                 .fallbackEnabled(false)
                 .build();
-        HystrixConfigurationFactory.updateWithNewHystrixConfig("TestCommand", commandConfig);
+        SimpleTestCommand command111 = new SimpleTestCommand(commandConfig);
+        String result1 = command111.queue().get();
+        Assert.assertTrue(result1.equals("Simple Test"));
     }
 
 
@@ -50,10 +61,8 @@ public class HystrixConfigurationDynamicUpdateTest {
             String result = command3.queue().get();
             Assert.assertTrue(result.equals("Simple Test"));
         } catch (Exception e) {
-            changeTimeout("TestCommand");
-            SimpleTestCommand command111 = new SimpleTestCommand(null);
-            String result1 = command111.queue().get();
-            Assert.assertTrue(result1.equals("Simple Test"));
+            changeTimeoutAndTest("TestCommand");
+
         }
     }
 

--- a/src/test/java/com/hystrix/configutator/HystrixConfigurationDynamicUpdateTest.java
+++ b/src/test/java/com/hystrix/configutator/HystrixConfigurationDynamicUpdateTest.java
@@ -1,0 +1,81 @@
+package com.hystrix.configutator;
+
+import com.hystrix.configurator.config.CircuitBreakerConfig;
+import com.hystrix.configurator.config.CommandThreadPoolConfig;
+import com.hystrix.configurator.config.HystrixCommandConfig;
+import com.hystrix.configurator.config.HystrixConfig;
+import com.hystrix.configurator.config.HystrixDefaultConfig;
+import com.hystrix.configurator.config.MetricsConfig;
+import com.hystrix.configurator.core.BaseCommand;
+import com.hystrix.configurator.core.HystrixConfigurationFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+public class HystrixConfigurationDynamicUpdateTest {
+
+    private void changeTimeout() {
+        if (HystrixConfigurationFactory.getCommandCache().containsKey("TestCommand")) {
+
+            HystrixConfigurationFactory.getCommandCache().remove("TestCommand");
+            HystrixConfigurationFactory.getPoolCache().remove("command_TestCommand");
+
+            HystrixCommandConfig commandConfig1 = HystrixCommandConfig.builder()
+                    .name("TestCommand")
+                    .semaphoreIsolation(false)
+                    .threadPool(CommandThreadPoolConfig.builder().timeout(4000).build())
+                    .metrics(MetricsConfig.builder().build())
+                    .circuitBreaker(CircuitBreakerConfig.builder().build())
+                    .fallbackEnabled(false)
+                    .build();
+
+            HystrixConfigurationFactory.getOrSetCommandConfiguration("TestCommand", commandConfig1);
+            log.info("Works!!!!");
+        }
+    }
+
+
+    @Test
+    public void dynamicConfig() throws ExecutionException, InterruptedException {
+        try {
+            HystrixCommandConfig commandConfig = HystrixCommandConfig.builder()
+                    .name("TestCommand")
+                    .semaphoreIsolation(false)
+                    .threadPool(CommandThreadPoolConfig.builder().timeout(1000).build())
+                    .metrics(MetricsConfig.builder().build())
+                    .circuitBreaker(CircuitBreakerConfig.builder().build())
+                    .fallbackEnabled(false)
+                    .build();
+
+            SimpleTestCommand command3 = new SimpleTestCommand(commandConfig);
+            String result = command3.queue().get();
+            Assert.assertTrue(result.equals("Simple Test"));
+        } catch (Exception e) {
+            changeTimeout();
+            SimpleTestCommand command111 = new SimpleTestCommand(null);
+            String result1 = command111.queue().get();
+            Assert.assertTrue(result1.equals("Simple Test"));
+        }
+    }
+
+    public static class SimpleTestCommand extends BaseCommand<String> {
+
+        HystrixCommandConfig commandConfig;
+
+        public SimpleTestCommand(HystrixCommandConfig commandConfig) {
+            super("TestCommand", commandConfig);
+        }
+
+        @Override
+        protected String run() throws InterruptedException {
+            Thread.sleep(2000);
+            return "Simple Test";
+        }
+    }
+}


### PR DESCRIPTION
In Hystrix configurator, if you add new Hystrix command at runtime it takes default hystrix configuration. 
Instead of default config, we have use-case to get hystrix configuration from db and add it to Hystrix (runtime). It could be new hystrix command or updating the existing configuration.