### PR TITLE
exposing force closed property of circuit breaker

### DIFF
--- a/src/main/java/com/hystrix/configurator/config/CircuitBreakerConfig.java
+++ b/src/main/java/com/hystrix/configurator/config/CircuitBreakerConfig.java
@@ -33,11 +33,16 @@ public class CircuitBreakerConfig {
 
     private int errorThreshold = 50;
 
+    private boolean forceClosed;
+
+
     @Builder
-    public CircuitBreakerConfig(int acceptableFailuresInWindow, int waitTimeBeforeRetry, int errorThreshold) {
+    public CircuitBreakerConfig(int acceptableFailuresInWindow, int waitTimeBeforeRetry,
+        int errorThreshold, boolean forceClosed) {
         this.acceptableFailuresInWindow = acceptableFailuresInWindow;
         this.waitTimeBeforeRetry = waitTimeBeforeRetry;
         this.errorThreshold = errorThreshold;
+        this.forceClosed = forceClosed;
     }
 
     //Default values
@@ -48,5 +53,7 @@ public class CircuitBreakerConfig {
         private int waitTimeBeforeRetry = 5000;
 
         private int errorThreshold = 50;
+
+        private boolean forceClosed = false;
     }
 }

--- a/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
+++ b/src/main/java/com/hystrix/configurator/core/HystrixConfigurationFactory.java
@@ -97,6 +97,7 @@ public class HystrixConfigurationFactory {
         configureProperty("hystrix.command.default.circuitBreaker.requestVolumeThreshold", defaultConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
         configureProperty("hystrix.command.default.circuitBreaker.errorThresholdPercentage", defaultConfig.getCircuitBreaker().getErrorThreshold());
         configureProperty("hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds", defaultConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
+        configureProperty("hystrix.command.default.circuitBreaker.forceClosed", defaultConfig.getCircuitBreaker().isForceClosed());
 
         configureProperty("hystrix.command.default.metrics.rollingStats.timeInMilliseconds", defaultConfig.getMetrics().getStatsTimeInMillis());
         configureProperty("hystrix.command.default.metrics.rollingStats.numBuckets", defaultConfig.getMetrics().getNumBucketSize());
@@ -167,6 +168,7 @@ public class HystrixConfigurationFactory {
         configureProperty(String.format("hystrix.command.%s.circuitBreaker.requestVolumeThreshold", commandConfig.getName()), commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow());
         configureProperty(String.format("hystrix.command.%s.circuitBreaker.errorThresholdPercentage", commandConfig.getName()), commandConfig.getCircuitBreaker().getErrorThreshold());
         configureProperty(String.format("hystrix.command.%s.circuitBreaker.sleepWindowInMilliseconds", commandConfig.getName()), commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry());
+        configureProperty(String.format("hystrix.command.%s.circuitBreaker.forceClosed", commandConfig.getName()), commandConfig.getCircuitBreaker().isForceClosed());
 
         configureProperty(String.format("hystrix.command.%s.metrics.rollingStats.timeInMilliseconds", commandConfig.getName()), commandConfig.getMetrics().getStatsTimeInMillis());
         configureProperty(String.format("hystrix.command.%s.metrics.rollingStats.numBuckets", commandConfig.getName()), commandConfig.getMetrics().getNumBucketSize());
@@ -183,6 +185,7 @@ public class HystrixConfigurationFactory {
                 .withCircuitBreakerErrorThresholdPercentage(commandConfig.getCircuitBreaker().getErrorThreshold())
                 .withCircuitBreakerRequestVolumeThreshold(commandConfig.getCircuitBreaker().getAcceptableFailuresInWindow())
                 .withCircuitBreakerSleepWindowInMilliseconds(commandConfig.getCircuitBreaker().getWaitTimeBeforeRetry())
+                .withCircuitBreakerForceClosed(commandConfig.getCircuitBreaker().isForceClosed())
                 .withExecutionTimeoutInMilliseconds(commandConfig.getThreadPool().getTimeout())
                 .withMetricsHealthSnapshotIntervalInMilliseconds(commandConfig.getMetrics().getHealthCheckInterval())
                 .withMetricsRollingPercentileBucketSize(commandConfig.getMetrics().getPercentileBucketSize())


### PR DESCRIPTION
In the payment's drill checkout was expected to keep the circuit closed for payments. Even if we move the errorThreshold to 100%, hystrix opens the circuit as it honors on and above flag as per my understanding. [Code Pointer](https://github.com/Netflix/Hystrix/blob/7c03bafe32b518182e09e92fa57358a01043a504/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java#L186)

 Defining forceClosed flag explicitly to keep the circuits intact as this forceOpen is evaluated first, then forceClosed.